### PR TITLE
Add a 'links' property to comments

### DIFF
--- a/Comment Specification.md
+++ b/Comment Specification.md
@@ -29,6 +29,14 @@ The fields of a comment are (in order):
     Required to not be empty.
 4. `amender` - Person who committed the comment into git, in the same
     format as the author. Required to not be empty.
+5. `links:` - One or many reference URLs relating to the comment. Identifiers
+    and URLs follow on subsequent lines preceded by an asterisk in the format
+
+        * [identifier] <[URL]>
+
+    where `identifier` is a string composed of alphanumeric characters, dashes,
+    spaces, and underscores, which must be unique in the collection of links.
+    URL must be fully qualified with the protocol. The link key is optional.
 
 After the fields, there is a single empty line, then the content of the
 comment, which can be multiple lines.
@@ -40,6 +48,9 @@ commit 0155eb4229851634a0f03eb265b69f5a2d56f341
 file src/main.c:12
 author Delisa Mason <name@example.com> 1243040974 -0900
 amender Delisa Mason <name@example.com> 1243040974 -0900
+links:
+* Synchronization URL <https://example.com/project/issues/14/comments/123>
+* Related RFC <https://example.com/project/proposals/98>
 
 Too many levels of indentation here.
 

--- a/Comment Specification.md
+++ b/Comment Specification.md
@@ -4,10 +4,18 @@ Version: 0.1.0
 
 # Comment Specification
 
-Comments are regular git objects, stored in a format similar to tags,
-with the addition of file and line references and a flag for deletion.
-The fields of a comment are a single keyword followed by a space
-and the value. They are (in order):
+Comments are regular git objects, stored in a format similar to tags.
+
+## Field Types
+
+The fields of a comment are formatted as:
+* A single keyword followed by a space and the value, or
+* A single keyword ending in a colon followed by subsequent lines prefixed by an
+  asterisk.
+
+## Field Enumeration
+
+The fields of a comment are (in order):
 
 1. `commit` - Full hash of the commit to which the comment is attached.
     Required to be not empty.


### PR DESCRIPTION
This is a combination of two changes, first to add a new key-to-many values field type (`list`), and the second to use the new field type to add a `links` property to comments.

Fixes #3
## `list` Field Type
### Semantics
1. A list keyword contains no spaces and is terminated by a colon
2. The keyword is followed by a newline
3. Each subsequent value for the key is prefixed by an asterisk and a space
4. List items cannot contain newlines 
### Rationale

Comment objects are largely human-readable and simple overall, and this adds a more complex structure while maintaining that intent.
## `links:` property
### Rationale

Having one or many reference URLs should greatly assist in consistency when synchronizing from external systems. Making the property generic preventing tying `git-comment` to one particular system and might enable some unforeseen uses for referencing useful related content.
### Example

```
commit 0155eb4229851634a0f03eb265b69f5a2d56f341
file src/main.c:12
author Delisa Mason <name@example.com> 1243040974 -0900
amender Delisa Mason <name@example.com> 1243040974 -0900
links:
* Synchronization URL <https://example.com/project/issues/14/comments/123>
* Related RFC <https://example.com/project/proposals/98>

Too many levels of indentation here.

Consider updating the linter as well as a part of this changeset.
```
### Concerns
- Content in external systems may change
- Fetch time for URLs is not preserved, though can be presumed to be the time of authorship and/or amendment by comment writers
- This scheme only allows validating comment synchronization by referencing metadata and comment content, and does not create any fast lookup schemes by URL, et cetera
